### PR TITLE
Replace uglifyjs-webpack-plugin to terser-webpack-plugin

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -2,7 +2,7 @@ const { resolve, relative, dirname, basename, extname } = require('path')
 const { generateEntry } = require('webpacker-entry')
 const webpack = require('webpack')
 const ManifestPlugin = require('webpack-manifest-plugin')
-const UglifyJSPlugin = require('uglifyjs-webpack-plugin')
+const TerserWebpackPlugin = require('terser-webpack-plugin')
 
 module.exports = function generate(options = {}) {
   const baseDir = options.baseDir || resolve('./app/javascript/packs')
@@ -34,7 +34,7 @@ module.exports = function generate(options = {}) {
       new ManifestPlugin({ publicPath: '/packs/', writeToFileEmit: true })
     ],
     optimization: {
-      minimizer: [new UglifyJSPlugin()]
+      minimizer: [new TerserWebpackPlugin()]
     },
     resolve: {
       extensions


### PR DESCRIPTION
## Overview

When I ran `bin/rails assets:precompile`, the following error occurred:

```
ERROR in building/chunk-713223b4fcae3c5ffee9.chunk.js from UglifyJs
Unexpected token: keyword «const» [building/chunk-713223b4fcae3c5ffee9.chunk.js:84417,0]
```

That is because `uglify-js` does not support ES6…
I checked Webpacker (rails/webpacker#1816) and webpack (webpack/webpack#8036), they also faced the same problem and have already replaced `uglifyjs-webpack-plugin` to `terser-webpack-plugin`. You can see more details on webpack/webpack#8036.

## Changes

- [x] Replace `uglifyjs-webpack-plugin` to `terser-webpack-plugin` in `generate.js`.

I didn't add `terser-webpack-plugin` to dependencies because `uglifyjs-webpack-plugin` couldn't be found in `package.json` before changing. Please let me know if there is a problem!
